### PR TITLE
added optional encoding parameter for Dbt.from_file() and docstring to from_file() and from_url()

### DIFF
--- a/src/cube_dbt/dbt.py
+++ b/src/cube_dbt/dbt.py
@@ -1,8 +1,10 @@
 import json
 import locale
 from urllib.request import urlopen
+
 from cube_dbt.model import Model
-    
+
+
 class Dbt:
   def __init__(self, manifest: dict) -> None:
     self.manifest = manifest

--- a/src/cube_dbt/dbt.py
+++ b/src/cube_dbt/dbt.py
@@ -15,12 +15,12 @@ class Dbt:
         pass
 
     @staticmethod
-    def from_file(manifest_path: str, encoding=None) -> "Dbt":
+    def from_file(manifest_path: str, encoding: str = None) -> "Dbt":
         """Reads a DBT manifest.json file from local path
 
         Args:
             manifest_path (str): The path to the manifest file, read from the top-level directory of the Cube environment
-            encoding (_type_, optional): Encoding for the manifest.json file. Uses the system locale preferred encoding if not specified.
+            encoding (str, optional): Encoding for the manifest.json file. Uses the system locale preferred encoding if not specified.
 
         Returns:
             Dbt: Dbt manifest class to interact with in Cube

--- a/src/cube_dbt/dbt.py
+++ b/src/cube_dbt/dbt.py
@@ -1,18 +1,16 @@
 import json
 import locale
 from urllib.request import urlopen
-
 from cube_dbt.model import Model
-
-
+    
 class Dbt:
-    def __init__(self, manifest: dict) -> None:
-        self.manifest = manifest
-        self.paths = ""
-        self.tags = []
-        self.names = []
-        self._models = None
-        pass
+  def __init__(self, manifest: dict) -> None:
+    self.manifest = manifest
+    self.paths = ''
+    self.tags = []
+    self.names = []
+    self._models = None
+    pass
 
     @staticmethod
     def from_file(manifest_path: str, encoding: str = None) -> "Dbt":
@@ -45,36 +43,29 @@ class Dbt:
         with urlopen(manifest_url) as file:
             manifest = json.loads(file.read())
             return Dbt(manifest)
+    
+  def filter(self, paths: list[str]=[], tags: list[str]=[], names: list[str]=[]) -> 'Dbt':
+    self.paths = paths
+    self.tags = tags
+    self.names = names
+    return self
 
-    def filter(
-        self, paths: list[str] = [], tags: list[str] = [], names: list[str] = []
-    ) -> "Dbt":
-        self.paths = paths
-        self.tags = tags
-        self.names = names
-        return self
-
-    def _init_models(self):
-        if self._models == None:
-            self._models = list(
-                Model(node)
-                for key, node in self.manifest["nodes"].items()
-                if node["resource_type"] == "model"
-                and node["config"]["materialized"] != "ephemeral"
-                and (
-                    any(node["path"].startswith(path) for path in self.paths)
-                    if self.paths
-                    else True
-                )
-                and all(tag in node["config"]["tags"] for tag in self.tags)
-                and (node["name"] in self.names if self.names else True)
-            )
-
-    @property
-    def models(self) -> list[Model]:
-        self._init_models()
-        return self._models
-
-    def model(self, name: str) -> Model:
-        self._init_models()
-        return next(model for model in self._models if model.name == name)
+  def _init_models(self):
+    if self._models == None:
+      self._models = list(
+        Model(node) for key, node in self.manifest['nodes'].items()
+        if node['resource_type'] == 'model' and
+        node['config']['materialized'] != 'ephemeral' and
+        (any(node['path'].startswith(path) for path in self.paths) if self.paths else True) and
+        all(tag in node['config']['tags'] for tag in self.tags) and
+        (node['name'] in self.names if self.names else True)
+      )
+  
+  @property
+  def models(self) -> list[Model]:
+    self._init_models()
+    return self._models
+  
+  def model(self, name: str) -> Model:
+    self._init_models()
+    return next(model for model in self._models if model.name == name)

--- a/src/cube_dbt/dbt.py
+++ b/src/cube_dbt/dbt.py
@@ -6,13 +6,13 @@ from cube_dbt.model import Model
 
 
 class Dbt:
-  def __init__(self, manifest: dict) -> None:
-    self.manifest = manifest
-    self.paths = ''
-    self.tags = []
-    self.names = []
-    self._models = None
-    pass
+    def __init__(self, manifest: dict) -> None:
+        self.manifest = manifest
+        self.paths = ""
+        self.tags = []
+        self.names = []
+        self._models = None
+        pass
 
     @staticmethod
     def from_file(manifest_path: str, encoding: str = None) -> "Dbt":
@@ -45,29 +45,29 @@ class Dbt:
         with urlopen(manifest_url) as file:
             manifest = json.loads(file.read())
             return Dbt(manifest)
-    
-  def filter(self, paths: list[str]=[], tags: list[str]=[], names: list[str]=[]) -> 'Dbt':
-    self.paths = paths
-    self.tags = tags
-    self.names = names
-    return self
 
-  def _init_models(self):
-    if self._models == None:
-      self._models = list(
-        Model(node) for key, node in self.manifest['nodes'].items()
-        if node['resource_type'] == 'model' and
-        node['config']['materialized'] != 'ephemeral' and
-        (any(node['path'].startswith(path) for path in self.paths) if self.paths else True) and
-        all(tag in node['config']['tags'] for tag in self.tags) and
-        (node['name'] in self.names if self.names else True)
-      )
-  
-  @property
-  def models(self) -> list[Model]:
-    self._init_models()
-    return self._models
-  
-  def model(self, name: str) -> Model:
-    self._init_models()
-    return next(model for model in self._models if model.name == name)
+    def filter(self, paths: list[str]=[], tags: list[str]=[], names: list[str]=[]) -> 'Dbt':
+        self.paths = paths
+        self.tags = tags
+        self.names = names
+        return self
+
+    def _init_models(self):
+        if self._models == None:
+        self._models = list(
+            Model(node) for key, node in self.manifest['nodes'].items()
+            if node['resource_type'] == 'model' and
+            node['config']['materialized'] != 'ephemeral' and
+            (any(node['path'].startswith(path) for path in self.paths) if self.paths else True) and
+            all(tag in node['config']['tags'] for tag in self.tags) and
+            (node['name'] in self.names if self.names else True)
+        )
+    
+    @property
+    def models(self) -> list[Model]:
+        self._init_models()
+        return self._models
+    
+    def model(self, name: str) -> Model:
+        self._init_models()
+        return next(model for model in self._models if model.name == name)

--- a/src/cube_dbt/dbt.py
+++ b/src/cube_dbt/dbt.py
@@ -54,14 +54,14 @@ class Dbt:
 
     def _init_models(self):
         if self._models == None:
-        self._models = list(
-            Model(node) for key, node in self.manifest['nodes'].items()
-            if node['resource_type'] == 'model' and
-            node['config']['materialized'] != 'ephemeral' and
-            (any(node['path'].startswith(path) for path in self.paths) if self.paths else True) and
-            all(tag in node['config']['tags'] for tag in self.tags) and
-            (node['name'] in self.names if self.names else True)
-        )
+            self._models = list(
+                Model(node) for key, node in self.manifest['nodes'].items()
+                if node['resource_type'] == 'model' and
+                node['config']['materialized'] != 'ephemeral' and
+                (any(node['path'].startswith(path) for path in self.paths) if self.paths else True) and
+                all(tag in node['config']['tags'] for tag in self.tags) and
+                (node['name'] in self.names if self.names else True)
+            )
     
     @property
     def models(self) -> list[Model]:

--- a/src/cube_dbt/dbt.py
+++ b/src/cube_dbt/dbt.py
@@ -1,51 +1,80 @@
 import json
-
+import locale
 from urllib.request import urlopen
+
 from cube_dbt.model import Model
-    
+
+
 class Dbt:
-  def __init__(self, manifest: dict) -> None:
-    self.manifest = manifest
-    self.paths = ''
-    self.tags = []
-    self.names = []
-    self._models = None
-    pass
+    def __init__(self, manifest: dict) -> None:
+        self.manifest = manifest
+        self.paths = ""
+        self.tags = []
+        self.names = []
+        self._models = None
+        pass
 
-  @staticmethod
-  def from_file(manifest_path: str) -> 'Dbt':
-    with open(manifest_path, 'r') as file:
-      manifest = json.loads(file.read())
-      return Dbt(manifest)
+    @staticmethod
+    def from_file(manifest_path: str, encoding=None) -> "Dbt":
+        """Reads a DBT manifest.json file from local path
 
-  @staticmethod
-  def from_url(manifest_url: str) -> 'Dbt':
-    with urlopen(manifest_url) as file:
-      manifest = json.loads(file.read())
-      return Dbt(manifest)
-    
-  def filter(self, paths: list[str]=[], tags: list[str]=[], names: list[str]=[]) -> 'Dbt':
-    self.paths = paths
-    self.tags = tags
-    self.names = names
-    return self
+        Args:
+            manifest_path (str): The path to the manifest file, read from the top-level directory of the Cube environment
+            encoding (_type_, optional): Encoding for the manifest.json file. Uses the system locale preferred encoding if not specified.
 
-  def _init_models(self):
-    if self._models == None:
-      self._models = list(
-        Model(node) for key, node in self.manifest['nodes'].items()
-        if node['resource_type'] == 'model' and
-        node['config']['materialized'] != 'ephemeral' and
-        (any(node['path'].startswith(path) for path in self.paths) if self.paths else True) and
-        all(tag in node['config']['tags'] for tag in self.tags) and
-        (node['name'] in self.names if self.names else True)
-      )
-  
-  @property
-  def models(self) -> list[Model]:
-    self._init_models()
-    return self._models
-  
-  def model(self, name: str) -> Model:
-    self._init_models()
-    return next(model for model in self._models if model.name == name)
+        Returns:
+            Dbt: Dbt manifest class to interact with in Cube
+        """
+        if encoding is None:
+            encoding = locale.getpreferredencoding()
+        with open(manifest_path, "r", encoding=encoding) as file:
+            manifest = json.loads(file.read())
+            return Dbt(manifest)
+
+    @staticmethod
+    def from_url(manifest_url: str) -> "Dbt":
+        """
+        Creates an instance of the Dbt class by loading a JSON manifest from a specified URL.
+
+        Args:
+            manifest_url (str): The URL pointing to the JSON manifest file. This URL should be accessible and the file should be in a valid JSON format.
+
+        Returns:
+            Dbt: An instance of the Dbt class initialized with the manifest loaded from the given URL.
+        """
+        with urlopen(manifest_url) as file:
+            manifest = json.loads(file.read())
+            return Dbt(manifest)
+
+    def filter(
+        self, paths: list[str] = [], tags: list[str] = [], names: list[str] = []
+    ) -> "Dbt":
+        self.paths = paths
+        self.tags = tags
+        self.names = names
+        return self
+
+    def _init_models(self):
+        if self._models == None:
+            self._models = list(
+                Model(node)
+                for key, node in self.manifest["nodes"].items()
+                if node["resource_type"] == "model"
+                and node["config"]["materialized"] != "ephemeral"
+                and (
+                    any(node["path"].startswith(path) for path in self.paths)
+                    if self.paths
+                    else True
+                )
+                and all(tag in node["config"]["tags"] for tag in self.tags)
+                and (node["name"] in self.names if self.names else True)
+            )
+
+    @property
+    def models(self) -> list[Model]:
+        self._init_models()
+        return self._models
+
+    def model(self, name: str) -> Model:
+        self._init_models()
+        return next(model for model in self._models if model.name == name)


### PR DESCRIPTION
I encountered encoding error while testing Cube Core and trying to load my manifest.json from file. My manifest.json file was utf-8 encoded, which caused `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 10168: `. 

Python version 3.9 which Cube Core docker image is using defaults to locale.getprefferedencoding(), which seems to be ascii on the docker image of Cube Core.

- Added numpy docstring for from_file() and from_url() methods
- Added possibility to set desired encoding for a local file. It not set, defaults to locale.getpreferredencoding()

Example of usage with Dbt.from_file():

```
from cube_dbt import Dbt

# with utf-8 encoding
dbt = Dbt.from_file("path/to/manifest.json", encoding="utf-8").filter(paths=["marts/"])

# without specifying encoding
dbt = Dbt.from_file("path/to/manifest.json").filter(paths=["marts/"])
```

Not needed in from_url() method because urlopen uses Content-Type headers to set encoding.