### PR TITLE
added encoding option, docstring and kept format of original file

### DIFF
--- a/src/cube_dbt/dbt.py
+++ b/src/cube_dbt/dbt.py
@@ -2,7 +2,8 @@ import json
 
 from urllib.request import urlopen
 from cube_dbt.model import Model
-    
+import locale
+
 class Dbt:
   def __init__(self, manifest: dict) -> None:
     self.manifest = manifest
@@ -13,16 +14,36 @@ class Dbt:
     pass
 
   @staticmethod
-  def from_file(manifest_path: str) -> 'Dbt':
-    with open(manifest_path, 'r') as file:
-      manifest = json.loads(file.read())
-      return Dbt(manifest)
+  def from_file(manifest_path: str, encoding:str = None) -> 'Dbt':
+    """Reads a DBT manifest.json file from local path
+
+    Args:
+        manifest_path (str): The path to the manifest file, read from the top-level directory of the Cube environment
+        encoding (str, optional): Encoding for the manifest.json file. Uses the system locale preferred encoding if not specified.
+
+    Returns:
+        Dbt: Dbt manifest class to interact with in Cube
+    """
+    if encoding is None:
+        encoding = locale.getpreferredencoding()
+    with open(manifest_path, "r", encoding=encoding) as file:
+        manifest = json.loads(file.read())
+        return Dbt(manifest)
 
   @staticmethod
   def from_url(manifest_url: str) -> 'Dbt':
+    """
+        Creates an instance of the Dbt class by loading a JSON manifest from a specified URL.
+
+        Args:
+            manifest_url (str): The URL pointing to the JSON manifest file. This URL should be accessible and the file should be in a valid JSON format.
+
+        Returns:
+            Dbt: An instance of the Dbt class initialized with the manifest loaded from the given URL.
+    """
     with urlopen(manifest_url) as file:
-      manifest = json.loads(file.read())
-      return Dbt(manifest)
+        manifest = json.loads(file.read())
+        return Dbt(manifest)
     
   def filter(self, paths: list[str]=[], tags: list[str]=[], names: list[str]=[]) -> 'Dbt':
     self.paths = paths


### PR DESCRIPTION
I encountered encoding error while testing Cube Core and trying to load my manifest.json from file. My manifest.json file was utf-8 encoded, which caused `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 10168: `. 

Python version 3.9 which Cube Core docker image is using defaults to locale.getprefferedencoding(), which seems to be ascii on the docker image of Cube Core.

- Added numpy docstring for from_file() and from_url() methods
- Added possibility to set desired encoding for a local file. It not set, defaults to locale.getpreferredencoding()

Example of usage with Dbt.from_file():

```
from cube_dbt import Dbt

# with utf-8 encoding
dbt = Dbt.from_file("path/to/manifest.json", encoding="utf-8").filter(paths=["marts/"])

# without specifying encoding
dbt = Dbt.from_file("path/to/manifest.json").filter(paths=["marts/"])
```

Not needed in from_url() method because urlopen uses Content-Type headers to set encoding.

** new PR from new branch to prevent too many file edits